### PR TITLE
Use css .hidden class instead of global hidden HTML attribute.

### DIFF
--- a/start.php
+++ b/start.php
@@ -76,7 +76,7 @@ function notifier_topbar_menu_setup ($hook, $type, $return, $params) {
 			}
 			$hidden = '';
 		} else {
-			$hidden = 'hidden';
+			$hidden = 'class="hidden"';
 		}
 
 		$text .= "<span id=\"notifier-new\" $hidden>$count</span>";

--- a/views/default/js/notifier/notifier.js
+++ b/views/default/js/notifier/notifier.js
@@ -86,15 +86,15 @@ define(function(require) {
 					$('#notifier-popup > .elgg-body > ul').html(output);
 
 					// Hide the "No notifications" texts
-					$('.notifier-none').attr('hidden', '');
+					$('.notifier-none').addClass('hidden');
 
 					// Display the "View all" link
-					$('#notifier-view-all').removeAttr('hidden');
+					$('#notifier-view-all').removeClass('hidden');
 
 					// Check if there are unread notifications
 					if ($('.elgg-notifier-unread').length) {
 						// Display the "Dismiss all" icon
-						$('#notifier-dismiss-all').removeAttr('hidden');
+						$('#notifier-dismiss-all').removeClass('hidden');
 					}
 
 					// Check if there are links that trigger a lightbox
@@ -108,10 +108,10 @@ define(function(require) {
 					$('#notifier-popup > .elgg-body > ul').html('');
 
 					// Hide the "Dismiss all" icon & the "View all" link
-					$('#notifier-dismiss-all, #notifier-view-all').attr('hidden', '');
+					$('#notifier-dismiss-all, #notifier-view-all').addClass('hidden');
 
 					// Display the "No notifications" text
-					$('.notifier-none').removeAttr('hidden');
+					$('.notifier-none').removeClass('hidden');
 				}
 			}
 		});

--- a/views/default/notifier/popup.php
+++ b/views/default/notifier/popup.php
@@ -9,7 +9,6 @@ $dismiss_link = elgg_view('output/url', array(
 	'title' => elgg_echo('notifier:dismiss_all'),
 	'class' => 'float-alt',
 	'id' => 'notifier-dismiss-all',
-	'hidden' => '',
 	'is_action' => true,
 	'is_trusted' => true,
 ));
@@ -28,7 +27,6 @@ $show_all_link = elgg_view('output/url', array(
 	'text' => elgg_echo('notifier:view:all'),
 	'class' => 'float',
 	'id' => 'notifier-view-all',
-	'hidden' => '',
 	'is_trusted' => true,
 ));
 


### PR DESCRIPTION
IE10 and below don't support the 'hidden' HTML attribute.  Using Elgg's .hidden class (i.e., "display:none;") works in all browsers.